### PR TITLE
Border shows days since last comment

### DIFF
--- a/lib/build_monitor.rb
+++ b/lib/build_monitor.rb
@@ -40,7 +40,7 @@ get '/' do
 
   @flattened_pull_requests = @pull_requests.values.flatten
   @pull_request_count = @flattened_pull_requests.count
-  @pull_request_days = @flattened_pull_requests.reduce(0) { |memo, request| memo + request.days_open }
+  @pull_request_days = @flattened_pull_requests.reduce(0) { |memo, request| memo + request.days_since_last_update }
 
   haml :index
 end

--- a/lib/pull_requests.rb
+++ b/lib/pull_requests.rb
@@ -1,7 +1,7 @@
 require 'github_api'
 require 'time_difference'
 
-PullRequest = Struct.new(:title, :user_avatar_url, :build_status, :days_open)
+PullRequest = Struct.new(:title, :user_avatar_url, :build_status, :days_since_last_update)
 
 class PullRequests
   def initialize(opts={})
@@ -18,7 +18,7 @@ class PullRequests
           pull.title,
           pull.user.avatar_url,
           build_status(repo_name, pull.head.sha),
-          days_open(pull.created_at)
+          days_since(pull.updated_at)
         )
       end.sort_by(&:title)
       hash[repo_name] = requests unless requests.empty?
@@ -56,7 +56,7 @@ private
     end
   end
 
-  def days_open(created_time)
-    TimeDifference.between(Time.now, Time.parse(created_time)).in_days
+  def days_since(time)
+    TimeDifference.between(Time.now, Time.parse(time)).in_days
   end
 end

--- a/public/index.css
+++ b/public/index.css
@@ -21,6 +21,11 @@ h3 {
   font-size: 36px;
 }
 
+p {
+  margin: 0;
+  padding-left: 10px;
+}
+
 .project-requests {
   background: #f8f8f8;
   margin: 10px;

--- a/views/pull_requests.haml
+++ b/views/pull_requests.haml
@@ -2,6 +2,7 @@
 %section{style: "border: #{border_size}px solid red"}
   %h2
     = "Pull Requests (#{@pull_request_count})"
+  %p Days since last update in [brackets]
   - @pull_requests.each do |project, requests|
     .project-requests
       %h3
@@ -13,8 +14,8 @@
               %img{src: request.user_avatar_url, width: 30, height: 30}
             %td.title
               %div
-                - title_text = "#{request.title} [#{request.days_open.to_i}d]"
-                - if request.days_open.to_i > 14
+                - title_text = "#{request.title} [#{request.days_since_last_update.to_i}d]"
+                - if request.days_since_last_update.to_i > 14
                   %b
                     = title_text
                 - else


### PR DESCRIPTION
Border now shows days since last comment, rather than the number of days the PR is open. This allows us to get feedback early, but still penalises stale PRs.

Also added explanatory note to PR column.