### PR TITLE
Use Octokit for PullRequests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'haml'
-gem 'github_api'
+gem 'octokit'
 gem 'time_difference'
 
 group :development do
   gem 'sinatra-reloader'
   gem 'capistrano'
-  gem 'pry'
+  gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,12 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     backports (2.8.2)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     capistrano (2.14.2)
       highline
       net-scp (>= 1.0.0)
@@ -15,28 +20,18 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     coderay (1.1.0)
+    columnize (0.8.9)
+    debugger-linecache (1.2.0)
     eventmachine (1.0.0)
-    faraday (0.8.5)
-      multipart-post (~> 1.1)
-    github_api (0.9.0)
-      faraday (~> 0.8.1)
-      hashie (~> 1.2.0)
-      multi_json (~> 1.4)
-      nokogiri (~> 1.5.2)
-      oauth2
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
     haml (3.1.7)
-    hashie (1.2.0)
     highline (1.6.16)
-    httpauth (0.2.0)
     i18n (0.6.11)
     json (1.8.1)
-    jwt (0.1.5)
-      multi_json (>= 1.0)
     method_source (0.8.2)
     minitest (5.4.3)
-    multi_json (1.6.1)
-    multi_xml (0.5.3)
-    multipart-post (1.1.5)
+    multipart-post (2.0.0)
     net-scp (1.1.0)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.1)
@@ -44,23 +39,23 @@ GEM
     net-ssh (2.6.6)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    nokogiri (1.5.6)
-    oauth2 (0.9.0)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
-      multi_xml (~> 0.5)
-      rack (~> 1.2)
+    octokit (2.7.2)
+      sawyer (~> 0.5.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (2.0.0)
+      byebug (~> 3.4)
+      pry (~> 0.10)
     rack (1.5.1)
     rack-protection (1.3.2)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    sawyer (0.5.5)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -87,9 +82,9 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano
-  github_api
   haml
-  pry
+  octokit
+  pry-byebug
   sinatra
   sinatra-reloader
   time_difference


### PR DESCRIPTION
https://reevoo.atlassian.net/browse/PROD-1090

Using Octokit allows us to use the Search API, reducing the number of requests we make to the API.

Also, it appeared that `github_api` couldn't return more than 100 repositories (or I couldn't work the pagination...), which was why we were losing Pull Requests from the list.